### PR TITLE
Fix the issue when using latest python libraries on python 3.10+

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+__pycache__
+dataset
+runs

--- a/common/load_data_hm36.py
+++ b/common/load_data_hm36.py
@@ -160,7 +160,7 @@ class Fusion(data.Dataset):  #crop:0, downsample:0  pad:0    stride:1
         bb_box = np.array([0, 0, 1, 1])
         input_2D_update = input_2D
 
-        scale = np.float(1.0)
+        scale = float(1.0)
 
         return cam, gt_3D, input_2D_update, action, subject, scale, bb_box, cam_ind
 

--- a/main.py
+++ b/main.py
@@ -132,7 +132,7 @@ if __name__ == '__main__':
     lr = opt.lr
     all_param += list(model.parameters())
     optimizer = optim.Adam(all_param, lr=opt.lr, amsgrad=True)
-    scheduler = torch.optim.lr_scheduler.ReduceLROnPlateau(optimizer, 'min', factor=0.317, patience=5, verbose=True)
+    scheduler = torch.optim.lr_scheduler.ReduceLROnPlateau(optimizer, 'min', factor=0.317, patience=5)
 
     for epoch in range(1, opt.nepoch):
         if opt.train:

--- a/model/Block.py
+++ b/model/Block.py
@@ -3,7 +3,7 @@ import torch
 import torch.nn as nn
 
 from timm.data import IMAGENET_DEFAULT_MEAN, IMAGENET_DEFAULT_STD
-from timm.models.layers import DropPath
+from timm.layers import DropPath
 from model.GCN_conv import ModulatedGraphConv
 from model.Transformer import Attention, Mlp
 

--- a/requirement.txt
+++ b/requirement.txt
@@ -4,3 +4,8 @@ tensorboardX
 scipy
 filterpy
 tqdm
+yacs
+opencv-python
+numba
+scikit-image
+IPython


### PR DESCRIPTION
Hi @vefalun , this work of yours is great. but the program was not running in latest environment. So I created a fix to work in latest python packages(as installation from requirements.txt installed latest packages).

Here are the changes I made:
* Updated import statements for `timm` modules to align with current (non-deprecated) usage.
* Removed the `verbose` parameter from `ReduceLROnPlateau` to match changes in PyTorch 2.1, where this argument is no longer supported.
* Replaced `np.float(1.0)` with a standard `float` to maintain compatibility with NumPy 2.x, which removed `np.float`.
* Added `.gitignore` and `requirements.txt` files for easier project setup and environment replication.

Thanks for making your work public